### PR TITLE
Delaying sending of the action

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var BUFFERED_ACTION_RETURN = 'redux-action-buffer: buffered action'
 
+var setImmediate = typeof global !== 'undefined' && typeof global.setImmediate !== 'undefined' ? global.setImmediate : setTimeout
+
 module.exports = function bufferActions (breaker, cb) {
   var active = true
   var queue = []
@@ -22,14 +24,16 @@ module.exports = function bufferActions (breaker, cb) {
         if (breaker(action)) {
           active = false
           var result = next(action)
-          var queueResults = []
-          queue.forEach(function (queuedAction) {
-            var queuedActionResult = next(queuedAction)
-            queueResults.push(queuedActionResult)
-          })
-          cb && cb(null, {
-            results: queueResults,
-            queue: queue
+          setImmediate(function () {
+            var queueResults = []
+            queue.forEach(function (queuedAction) {
+              var queuedActionResult = next(queuedAction)
+              queueResults.push(queuedActionResult)
+            })
+            cb && cb(null, {
+              results: queueResults,
+              queue: queue
+            })
           })
           return result
         } else {

--- a/test/tests.js
+++ b/test/tests.js
@@ -40,10 +40,12 @@ test('buffers actions', t => {
   t.same(rB, breaker)
   t.same(r3, action3)
 
-  // history is re-ordered as expected
-  t.is(actionHistory.indexOf(breaker), 0)
-  t.is(actionHistory.indexOf(action1), 1)
-  t.is(actionHistory.indexOf(action2), 2)
-  t.is(actionHistory.indexOf(action3), 3)
-  t.pass()
+  setTimeout(function () {
+    // history is re-ordered as expected
+    t.is(actionHistory.indexOf(breaker), 0)
+    t.is(actionHistory.indexOf(action1), 1)
+    t.is(actionHistory.indexOf(action2), 2)
+    t.is(actionHistory.indexOf(action3), 3)
+    t.pass()
+  }, 1000)
 })


### PR DESCRIPTION
One of the ways to fix https://github.com/rt2zz/redux-action-buffer/issues/9 is to delay the sending of the message

The other way is to edit redux-persist to fire the action only after the persistor has been resumed. 

However I like this solution more. (If only because this module is used less and I cannot break that many things by changing it :D ) 